### PR TITLE
Fix: Add missing class validator dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+Dockerfile
+.git
+.gitignore
+.npmrc
+.env

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ $ npm run test:cov
 
 ### API Documentation + Test Endpoints
 
-[Swagger API](https://tappd.herokuapp.com/api/)
+[Swagger API](https://tappd-be.herokuapp.com/api)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
  <h2 align="center">Tappd Backend</h2>
  <p align="center">Backend Server in NestJS for Tappd.</p>
 </p>
+<p align="center">
+    <img alt="Build" src="https://github.com/tappd-sg/tappd-backend/actions/workflows/build.yaml/badge.svg" />
+    <img alt="CodeQL" src="https://github.com/tappd-sg/tappd-backend/actions/workflows/codeql-analysis.yml/badge.svg" />
+</p>
 
 ## Quick Start
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tappd",
+      "name": "tappd-backend",
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
@@ -14,6 +14,7 @@
         "@nestjs/core": "^8.0.6",
         "@nestjs/platform-express": "^8.0.6",
         "@nestjs/swagger": "^5.0.9",
+        "class-validator": "^0.13.1",
         "joi": "^17.4.2",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
@@ -2243,8 +2244,7 @@
     "node_modules/@types/validator": {
       "version": "13.6.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
-      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw==",
-      "peer": true
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -3286,7 +3286,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
       "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.1.3",
         "libphonenumber-js": "^1.9.7",
@@ -6549,8 +6548,7 @@
     "node_modules/libphonenumber-js": {
       "version": "1.9.34",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.34.tgz",
-      "integrity": "sha512-gHTNU9xTtVgSp30IDX/57W4pETMXDIYXFfwEOJVXiYosiY7Hc7ogJwlBjOqlCcU04X0aA8DT57hdwUC1sJBJnA==",
-      "peer": true
+      "integrity": "sha512-gHTNU9xTtVgSp30IDX/57W4pETMXDIYXFfwEOJVXiYosiY7Hc7ogJwlBjOqlCcU04X0aA8DT57hdwUC1sJBJnA=="
     },
     "node_modules/lines-and-columns": {
       "version": "1.1.6",
@@ -8983,7 +8981,6 @@
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
       "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -11220,8 +11217,7 @@
     "@types/validator": {
       "version": "13.6.3",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
-      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw==",
-      "peer": true
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -12005,7 +12001,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
       "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
-      "peer": true,
       "requires": {
         "@types/validator": "^13.1.3",
         "libphonenumber-js": "^1.9.7",
@@ -14515,8 +14510,7 @@
     "libphonenumber-js": {
       "version": "1.9.34",
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.34.tgz",
-      "integrity": "sha512-gHTNU9xTtVgSp30IDX/57W4pETMXDIYXFfwEOJVXiYosiY7Hc7ogJwlBjOqlCcU04X0aA8DT57hdwUC1sJBJnA==",
-      "peer": true
+      "integrity": "sha512-gHTNU9xTtVgSp30IDX/57W4pETMXDIYXFfwEOJVXiYosiY7Hc7ogJwlBjOqlCcU04X0aA8DT57hdwUC1sJBJnA=="
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -16319,8 +16313,7 @@
     "validator": {
       "version": "13.6.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
-      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==",
-      "peer": true
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^8.0.6",
         "@nestjs/platform-express": "^8.0.6",
         "@nestjs/swagger": "^5.0.9",
+        "class-transformer": "^0.4.0",
         "class-validator": "^0.13.1",
         "joi": "^17.4.2",
         "reflect-metadata": "^0.1.13",
@@ -3279,8 +3280,7 @@
     "node_modules/class-transformer": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
-      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
-      "peer": true
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
     },
     "node_modules/class-validator": {
       "version": "0.13.1",
@@ -11994,8 +11994,7 @@
     "class-transformer": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
-      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==",
-      "peer": true
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
     },
     "class-validator": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tappd",
+  "name": "tappd-backend",
   "version": "0.0.1",
   "description": "Backend server for Tappd",
   "author": "Tappd",
@@ -27,6 +27,7 @@
     "@nestjs/core": "^8.0.6",
     "@nestjs/platform-express": "^8.0.6",
     "@nestjs/swagger": "^5.0.9",
+    "class-validator": "^0.13.1",
     "joi": "^17.4.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@nestjs/core": "^8.0.6",
     "@nestjs/platform-express": "^8.0.6",
     "@nestjs/swagger": "^5.0.9",
+    "class-transformer": "^0.4.0",
     "class-validator": "^0.13.1",
     "joi": "^17.4.2",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
## Changes in this PR

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change of an existing feature
-   [ ] Refactor/Performance enhancements

## Overview

- Missing dependency `class-validator` and `class-transformer` causing build to fail on heroku
